### PR TITLE
Fix stale-cached naxos.js breaking dark-mode toggle

### DIFF
--- a/app/forum/templates/base.html
+++ b/app/forum/templates/base.html
@@ -56,7 +56,7 @@
     <script src="{% static 'js/bootstrap.min.js' %}"></script>
     <script src="{% static 'js/bootstrap-colorpicker.min.js' %}"></script>  {# http://mjolnic.github.io/bootstrap-colorpicker/ #}
     <script src="/socket.io/socket.io.js"></script>
-    <script src="{% static 'js/naxos.js' %}"></script>
+    <script src="{% static 'js/naxos.js' %}?v=1"></script>
     {% get_media_prefix as media %}
   </head>
   <body>


### PR DESCRIPTION
## Summary

Fixes the dark-mode toggle appearing to do nothing for some users after #126.

- `naxos.css` and `dark.css` both carry a `?v=N` cache-busting query string in `base.html`; `naxos.js` had none.
- S3-served static assets have no `Cache-Control` header, so browsers apply heuristic caching based on `Last-Modified` — a browser that cached `naxos.js` before the dark-theme deploy keeps serving the old copy indefinitely, with no click handler on `.theme-toggle`.
- Result: the toggle button renders (server-rendered HTML, always fresh) and the pre-paint script still applies the OS preference, but clicking does nothing for anyone with a stale cached `naxos.js` — matching the reported symptom exactly (theme only follows system, manual toggle has no effect).

Fix: give `naxos.js` the same versioning convention as the CSS includes (`?v=1`).

## Test plan

- [x] Diagnosed locally with Playwright — dark-mode toggle works correctly on a fresh (uncached) session, both with and without emulated OS dark mode, confirming the bug is cache-related rather than logic-related
- [x] Verified against production (geekattitude.org) that `dark.css`/`naxos.js` content in S3 is current and correct — the bug is purely a client-cache issue on affected browsers, not a server-side one
- [x] Confirmed `base.html` renders `naxos.js?v=1` locally

## Next step

After merge, requires a full rebuild + push + redeploy (same pipeline as #126) for the new template to reach production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)