### PR TITLE
Support YouTube watch/short URLs in [video] tag

### DIFF
--- a/app/forum/utils/extra_tags.py
+++ b/app/forum/utils/extra_tags.py
@@ -1,5 +1,5 @@
 import re
-from urllib.parse import urlparse
+from urllib.parse import urlparse, parse_qs
 from .postmarkup.postmarkup import PostMarkup, TagBase, strip_bbcode
 
 
@@ -76,9 +76,55 @@ class VideoTag(TagBase):
 
     iframe_domains = ['youtube.com', 'player.vimeo.com', 'dailymotion.com']
 
+    _re_youtube_id = re.compile(r'^[A-Za-z0-9_-]{11}$')
+
     def __init__(self, name, annotate_links=False, **kwargs):
         super().__init__(name, inline=True)
         self.annotate_links = annotate_links
+
+    @classmethod
+    def _to_youtube_embed(cls, url):
+        """Rewrite a YouTube watch/short URL into its embeddable form.
+
+        Users can paste the URL from the address bar
+        (``https://www.youtube.com/watch?v=ID``) or the "share" button
+        (``https://youtu.be/ID``); both are turned into
+        ``https://www.youtube.com/embed/ID`` so the iframe works.
+
+        URLs already in the ``/embed/`` form (and any non-YouTube URL) are
+        returned unchanged, so videos posted before this change keep working.
+        """
+        try:
+            parts = urlparse(url)
+        except ValueError:
+            return url
+
+        host = parts.netloc.lower()
+        if host.startswith('www.'):
+            host = host[4:]
+
+        video_id = None
+        if host in ('youtube.com', 'm.youtube.com'):
+            if parts.path == '/watch':
+                video_id = (parse_qs(parts.query).get('v') or [None])[0]
+        elif host == 'youtu.be':
+            video_id = parts.path.lstrip('/').split('/')[0]
+
+        if not video_id or not cls._re_youtube_id.match(video_id):
+            return url
+
+        embed = 'https://www.youtube.com/embed/' + video_id
+        start = cls._youtube_start_seconds(parts.query)
+        if start:
+            embed += '?start=%d' % start
+        return embed
+
+    @staticmethod
+    def _youtube_start_seconds(query):
+        """Extract a start offset (in seconds) from a YouTube ``t`` param."""
+        values = parse_qs(query)
+        raw = (values.get('t') or values.get('start') or [''])[0].rstrip('s')
+        return int(raw) if raw.isdigit() else 0
 
     def render_open(self, parser, node_index):
 
@@ -105,6 +151,9 @@ class VideoTag(TagBase):
 
         if scheme not in [u'http', u'https']:
             return u''
+
+        url = self._to_youtube_embed(url)
+        scheme, uri = url.split(u':', 1)
 
         try:
             domain_match = self._re_domain.search(uri.lower())

--- a/app/forum/utils/test_extra_tags.py
+++ b/app/forum/utils/test_extra_tags.py
@@ -1,0 +1,54 @@
+from django.test import SimpleTestCase
+
+from .extra_tags import VideoTag
+
+
+class YouTubeEmbedTests(SimpleTestCase):
+    """Cover the YouTube URL normalisation used by the [video] tag (#118)."""
+
+    EMBED = 'https://www.youtube.com/embed/xvFZjo5PgG0'
+
+    def assertEmbed(self, url, expected=None):
+        self.assertEqual(VideoTag._to_youtube_embed(url), expected or self.EMBED)
+
+    def test_watch_url_is_rewritten(self):
+        self.assertEmbed('https://www.youtube.com/watch?v=xvFZjo5PgG0')
+
+    def test_watch_url_without_www(self):
+        self.assertEmbed('https://youtube.com/watch?v=xvFZjo5PgG0')
+
+    def test_mobile_watch_url(self):
+        self.assertEmbed('https://m.youtube.com/watch?v=xvFZjo5PgG0')
+
+    def test_short_youtu_be_url(self):
+        self.assertEmbed('https://youtu.be/xvFZjo5PgG0')
+
+    def test_extra_query_params_are_dropped(self):
+        self.assertEmbed('https://www.youtube.com/watch?v=xvFZjo5PgG0&list=PLabc')
+
+    def test_timestamp_becomes_start_param(self):
+        self.assertEmbed(
+            'https://www.youtube.com/watch?v=xvFZjo5PgG0&t=90s',
+            self.EMBED + '?start=90',
+        )
+        self.assertEmbed(
+            'https://youtu.be/xvFZjo5PgG0?t=42',
+            self.EMBED + '?start=42',
+        )
+
+    def test_already_embed_url_is_unchanged(self):
+        # Videos posted before #118 use the /embed/ form directly.
+        url = 'https://www.youtube.com/embed/xvFZjo5PgG0'
+        self.assertEqual(VideoTag._to_youtube_embed(url), url)
+
+    def test_non_youtube_url_is_unchanged(self):
+        for url in (
+            'https://player.vimeo.com/video/12345',
+            'https://example.com/clip.mp4',
+        ):
+            self.assertEqual(VideoTag._to_youtube_embed(url), url)
+
+    def test_invalid_video_id_is_left_untouched(self):
+        # Not a valid 11-char id: don't build a broken embed URL.
+        url = 'https://www.youtube.com/watch?v=not-a-real-id-too-long'
+        self.assertEqual(VideoTag._to_youtube_embed(url), url)


### PR DESCRIPTION
## Summary

Fixes #118. Users had to manually convert a YouTube watch URL into the `/embed/` form before the `[video]` tag would render it. Now the parser normalizes YouTube URLs when BBCode is rendered to HTML.

- Rewrites `youtube.com/watch?v=ID` (and `m.youtube.com`) and `youtu.be/ID` share links to `youtube.com/embed/ID`
- Preserves a `t=`/`start=` timestamp as `?start=<seconds>`
- Drops extra params (e.g. `&list=…`) for a clean embed
- **No regression:** existing `/embed/` URLs and non-YouTube URLs are left untouched, addressing the "Régression probable ?" concern in the issue
- Invalid video IDs are left as-is rather than producing a broken embed

## Test plan

- Added `app/forum/utils/test_extra_tags.py` (9 cases) covering watch, mobile, `youtu.be`, timestamp, extra-param, already-embed, non-YouTube, and invalid-id URLs — all pass via `manage.py test utils.test_extra_tags`
- Verified end-to-end through the running container that each case produces the correct iframe `src`

🤖 Generated with [Claude Code](https://claude.com/claude-code)