### PR TITLE
Keep embedded video in viewport when fullscreened on mobile

### DIFF
--- a/app/forum/static/css/naxos.css
+++ b/app/forum/static/css/naxos.css
@@ -185,3 +185,21 @@ div.legend {
 video {
     width: 100%;
 }
+/* Fullscreen: neutralise Bootstrap's `.embed-responsive iframe { position:absolute }`
+   so an embedded video fills the screen instead of overflowing it on mobile.
+   Prefixed and unprefixed forms are split: a selector list is dropped whole if a
+   browser doesn't understand one of its selectors. */
+.embed-responsive-item:fullscreen {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+.embed-responsive-item:-webkit-full-screen {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}

--- a/app/forum/templates/base.html
+++ b/app/forum/templates/base.html
@@ -42,7 +42,7 @@
     {# CSS #}
     <link href="{% static 'css/bootstrap.min.css' %}" rel="stylesheet">
     <link href="{% static 'css/bootstrap-colorpicker.min.css' %}" rel="stylesheet">  {# http://mjolnic.github.io/bootstrap-colorpicker/ #}
-    <link href="{% static 'css/naxos.css' %}?v=7" rel="stylesheet">
+    <link href="{% static 'css/naxos.css' %}?v=8" rel="stylesheet">
     <link href="{% static 'css/dark.css' %}?v=1" rel="stylesheet">
     <style type="text/css">
       /* Span content over screen width */


### PR DESCRIPTION
## Problem

A user reported that on mobile Chrome, tapping the YouTube fullscreen (two-arrows) button makes the video **too big and overflow the screen**:

> Par contre, sur mon smartphone, quand je veux mettre la vidéo en plein écran (avec l'icône des deux flèches), c'est trop grand, ça déborde de l'écran… Je suis sur chrome.

## Cause

Video embeds render inside Bootstrap 3's responsive-embed wrapper, whose rule absolutely-positions the iframe and sizes it to `width/height: 100%` of its container:

```css
.embed-responsive iframe { position: absolute; top:0; left:0; bottom:0; width:100%; height:100%; }
```

When the embedded player enters fullscreen, that `position: absolute` can leak into the fullscreen state on some mobile Chrome versions, so the video is sized to its in-page container / document rather than the screen and overflows. This is **pre-existing** — #128 only rewrote the YouTube URL string (`watch?v=`/`youtu.be` → `/embed/`) and didn't touch the embed markup or CSS; it just made embedding easy enough that people hit the old quirk.

## Fix

Add a `:fullscreen` override in `naxos.css` that pins the embed to `position: fixed` at 100% of the viewport. Prefixed and unprefixed variants are kept as **separate rules** on purpose — a CSS selector list is dropped entirely if the browser doesn't recognise one selector in it, which would otherwise skip the fix on older WebKit/Android Chrome. Cache-buster bumped `naxos.css?v=7` → `?v=8`.

## Verification

Reproduced the exact `VideoTag` markup with the real project CSS in Playwright (mobile Chrome, Pixel 5, 393×727), driving fullscreen both directly and from inside the iframe (as YouTube's button does):

| state | `position` | box | viewport | overflow |
|---|---|---|---|---|
| normal | `absolute` | 343×193 | — | layout unchanged |
| fullscreen | `fixed` | 393×727 | 393×727 | **no** |

## Caveat

Emulated Chromium already forces `position: fixed` in fullscreen via its `!important` UA rule, so the original overflow **isn't reproducible in an emulator** — the reporter's symptom lives in real Android Chrome's native fullscreen-video path, which device emulation doesn't exercise. This is the standard low-risk remedy for that class of bug and is a no-op on modern Chrome; the reporter should re-test on-device (ideally sharing their Chrome version + phone model) to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)