### PR TITLE
Add Dependabot config for version and security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,54 @@
+version: 2
+updates:
+  # --- Python (Pipenv) ---
+  - package-ecosystem: "pip"
+    directory: "/app/forum"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      python-forum:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/util"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      python-util:
+        patterns:
+          - "*"
+
+  # --- Node (websocket server) ---
+  - package-ecosystem: "npm"
+    directory: "/app/websocket"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      websocket-npm:
+        patterns:
+          - "*"
+
+  # --- Docker images ---
+  - package-ecosystem: "docker"
+    directory: "/app/forum"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/app/websocket"
+    schedule:
+      interval: "weekly"
+
+  # --- GitHub Actions workflows ---
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

The repo had **no `.github/dependabot.yml`**, so Dependabot was only running the two GitHub-side toggles (alerts + automated security fixes) — and those were producing **zero PRs** despite a large backlog of open vulnerability alerts (including 5 critical: Django SQL injection, Pillow RCE, npm `form-data`).

This adds a config covering every dependency ecosystem in the repo:

| Ecosystem | Directory |
|---|---|
| pip | `/app/forum` |
| pip | `/util` |
| npm | `/app/websocket` |
| docker | `/app/forum` |
| docker | `/app/websocket` |
| github-actions | `/` |

Updates are **grouped per ecosystem** and scheduled **weekly** to keep PR volume manageable given the backlog.

## Notes

- Dependabot only reads this config once it lands on the default branch (`master`).
- This does **not** by itself clear the existing critical-severity backlog — those stale deps (Django, Pillow, `form-data`) are being bumped separately.
- The `github-actions` entry will also keep the currently-outdated CodeQL workflow actions up to date once that workflow is modernized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)