### PR TITLE
Bootstrap tests for websocket service

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: test
+
+# Runs on PRs (to gate merges) and on pushes to master (post-merge).
+# Feature-branch pushes are covered by the pull_request event, avoiding
+# duplicate runs.
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  websocket:
+    name: websocket (node:test)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app/websocket
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      # The lib tests only use Node built-ins, so no install step is needed.
+      - run: node --test

--- a/app/websocket/lib.js
+++ b/app/websocket/lib.js
@@ -1,0 +1,47 @@
+'use strict';
+
+// Build the node_api notification URL for a user status change.
+const buildNotifyUrl = (baseUrl, user, status) =>
+  `${baseUrl}?${new URLSearchParams({sessionid: user, status})}`;
+
+// Create a fire-and-forget notifier for the django node_api endpoint.
+// `fetchImpl` and `onError` are injectable so the notifier can be unit tested
+// without a real network. Errors are swallowed (logged) to avoid unhandled
+// rejections, matching the previous `request` (no callback) behaviour.
+const makeNotifier = (baseUrl, {
+  fetchImpl = fetch,
+  onError = err => console.error('node_api notify failed:', err.message),
+} = {}) => (user, status) =>
+  fetchImpl(buildNotifyUrl(baseUrl, user, status)).catch(onError);
+
+// Reference-count a user's open sockets (e.g. multiple browser tabs) so django
+// is told "connected" only on the first socket and "disconnected" only on the
+// last. `connect` returns true on the first connection for a user; `disconnect`
+// returns true when the last connection for a user closes.
+const makeConnectionTracker = () => {
+  const counts = {};
+  return {
+    connect(user) {
+      if (user in counts) {
+        counts[user] += 1;
+        return false;
+      }
+      counts[user] = 1;
+      return true;
+    },
+    disconnect(user) {
+      const n = counts[user] || 0;
+      if (n <= 1) {
+        delete counts[user];
+        return n === 1;
+      }
+      counts[user] = n - 1;
+      return false;
+    },
+    count(user) {
+      return counts[user] || 0;
+    },
+  };
+};
+
+module.exports = {buildNotifyUrl, makeNotifier, makeConnectionTracker};

--- a/app/websocket/package.json
+++ b/app/websocket/package.json
@@ -1,6 +1,9 @@
 {
   "name": "naxos-node",
   "license": "Apache-2.0",
+  "scripts": {
+    "test": "node --test"
+  },
   "dependencies": {
     "cookie": "^0.7",
     "socket.io": "^3.0"

--- a/app/websocket/server.js
+++ b/app/websocket/server.js
@@ -1,20 +1,14 @@
 'use strict';
 const http = require('http');
 const cookie_reader = require('cookie');
+const {makeNotifier, makeConnectionTracker} = require('./lib');
 
 const {PORT, DEBUG, FORUM_URI} = process.env;
 
 const app = http.createServer().listen(PORT);
 const io = require('socket.io')(app);
-const connected_users = {};
-const url = `http://${FORUM_URI}/user/node_api`;
-
-// Fire-and-forget notification to django. Swallows errors to match the
-// previous `request` behaviour (no callback) and avoid unhandled rejections.
-const notifyForum = (user, status) => {
-  const params = new URLSearchParams({sessionid: user, status});
-  fetch(`${url}?${params}`).catch(err => console.error('node_api notify failed:', err.message));
-};
+const notifyForum = makeNotifier(`http://${FORUM_URI}/user/node_api`);
+const tracker = makeConnectionTracker();
 
 io.use((socket, next) => {
   const handshakeData = socket.request;
@@ -25,10 +19,7 @@ io.use((socket, next) => {
 });
 
 const handleConnection = (socket, user) => {
-  if (user in connected_users) {
-    connected_users[user] += 1;
-  } else {
-    connected_users[user] = 1;
+  if (tracker.connect(user)) {
     console.log(user + ' connected');
     // Tell django the user has come online
     notifyForum(user, 'connected');
@@ -38,13 +29,10 @@ const handleConnection = (socket, user) => {
 const handleDisconnection = (socket, user) => {
   socket.on('disconnect', () => {
     setTimeout(() => {
-      if (connected_users[user] === 1) {
-        delete connected_users[user];
+      if (tracker.disconnect(user)) {
         console.log(user + ' disconnected');
         // Tell django the user is now offline
         notifyForum(user, 'disconnected');
-      } else {
-        connected_users[user] -= 1;
       }
     }, 5000);
   });

--- a/app/websocket/test/lib.test.js
+++ b/app/websocket/test/lib.test.js
@@ -1,0 +1,96 @@
+'use strict';
+const {test} = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('node:http');
+const {buildNotifyUrl, makeNotifier, makeConnectionTracker} = require('../lib');
+
+const BASE = 'http://forum:5000/user/node_api';
+
+test('buildNotifyUrl builds the expected query string', () => {
+  assert.equal(
+    buildNotifyUrl(BASE, 'sess-abc123', 'connected'),
+    'http://forum:5000/user/node_api?sessionid=sess-abc123&status=connected'
+  );
+});
+
+test('buildNotifyUrl url-encodes special characters in the session id', () => {
+  assert.equal(
+    buildNotifyUrl(BASE, 'sess xyz&weird=1', 'disconnected'),
+    'http://forum:5000/user/node_api?sessionid=sess+xyz%26weird%3D1&status=disconnected'
+  );
+});
+
+test('makeNotifier calls fetch with the built url', async () => {
+  const calls = [];
+  const notify = makeNotifier(BASE, {fetchImpl: url => (calls.push(url), Promise.resolve())});
+  await notify('u1', 'connected');
+  assert.deepEqual(calls, [`${BASE}?sessionid=u1&status=connected`]);
+});
+
+test('makeNotifier swallows fetch failures (fire-and-forget)', async () => {
+  const errors = [];
+  const notify = makeNotifier(BASE, {
+    fetchImpl: () => Promise.reject(new Error('boom')),
+    onError: err => errors.push(err.message),
+  });
+  // Must not reject even though the underlying fetch rejected.
+  await assert.doesNotReject(notify('u1', 'connected'));
+  assert.deepEqual(errors, ['boom']);
+});
+
+test('makeNotifier works end-to-end against a real server with global fetch', async () => {
+  const received = [];
+  const server = http.createServer((req, res) => {
+    received.push(req.url);
+    res.writeHead(200);
+    res.end('ok');
+  });
+  await new Promise(resolve => server.listen(0, resolve));
+  try {
+    const {port} = server.address();
+    const notify = makeNotifier(`http://127.0.0.1:${port}/user/node_api`);
+    await notify('real-user', 'connected');
+    assert.deepEqual(received, ['/user/node_api?sessionid=real-user&status=connected']);
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+  }
+});
+
+test('tracker: first connect is the edge, extra tabs are not', () => {
+  const t = makeConnectionTracker();
+  assert.equal(t.connect('u'), true);   // first tab -> notify connected
+  assert.equal(t.connect('u'), false);  // second tab -> no notify
+  assert.equal(t.connect('u'), false);  // third tab -> no notify
+  assert.equal(t.count('u'), 3);
+});
+
+test('tracker: only the last disconnect is the edge', () => {
+  const t = makeConnectionTracker();
+  t.connect('u'); t.connect('u'); t.connect('u'); // 3 tabs open
+  assert.equal(t.disconnect('u'), false); // 2 left
+  assert.equal(t.disconnect('u'), false); // 1 left
+  assert.equal(t.disconnect('u'), true);  // last tab closed -> notify disconnected
+  assert.equal(t.count('u'), 0);
+});
+
+test('tracker: disconnect of an unknown user is not an edge', () => {
+  const t = makeConnectionTracker();
+  assert.equal(t.disconnect('ghost'), false);
+  assert.equal(t.count('ghost'), 0);
+});
+
+test('tracker: users are tracked independently', () => {
+  const t = makeConnectionTracker();
+  assert.equal(t.connect('a'), true);
+  assert.equal(t.connect('b'), true);
+  assert.equal(t.disconnect('a'), true);
+  assert.equal(t.count('a'), 0);
+  assert.equal(t.count('b'), 1);
+});
+
+test('tracker: a user can reconnect after fully disconnecting', () => {
+  const t = makeConnectionTracker();
+  t.connect('u');
+  assert.equal(t.disconnect('u'), true);
+  assert.equal(t.connect('u'), true); // fresh session -> edge again
+});


### PR DESCRIPTION
## Why

The websocket service had no test harness at all. This adds one so future changes (like the recent `request`→`fetch` migration in #138) have something to run against.

## Approach

**Zero new dependencies** — uses Node's built-in `node:test` runner, which fits the Node 20+ container runtime (Alpine `nodejs`).

The blocker: `server.js` starts a listening server *on import*, so it can't be required from a test. The testable logic is extracted into a side-effect-free `lib.js`:

- `buildNotifyUrl(base, user, status)` — pure URL/query builder.
- `makeNotifier(base, {fetchImpl, onError})` — the fire-and-forget node_api notifier, with injectable `fetch`/error handler for testing.
- `makeConnectionTracker()` — ref-counts a user's open sockets so django is notified only on the **first** connect and **last** disconnect (the multi-tab logic).

`server.js` is rewired to use these; **behaviour is unchanged**.

## Tests (`test/lib.test.js`, 10 cases)

- URL building + special-char encoding.
- Notifier calls fetch with the right URL; a rejected fetch is swallowed (fire-and-forget) and routed to `onError`.
- One end-to-end test against a real local HTTP server using the global `fetch`.
- Connection ref-counting edges: multi-tab connect, only-last-disconnect, unknown-user no-op, independent users, reconnect after full disconnect.

Run with `yarn test` (or `node --test`).

## Notes

- `makeConnectionTracker` is behaviour-faithful, with one hardened edge: disconnecting an untracked user is now a clean no-op (the original would decrement to `NaN`); neither notifies, so no observable change.
- Verified: `node --test` → 10 passed / 0 failed; `server.js` boots and listens with the new wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)