### PR TITLE
Fix bit-rotted forum tests and add them to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,3 +22,52 @@ jobs:
           node-version: '20'
       # The lib tests only use Node built-ins, so no install step is needed.
       - run: node --test
+
+  forum:
+    name: forum (django test)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: crimson
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      memcached:
+        # ForumUser's post_save signal writes to the cache, so a backend must
+        # be reachable (settings use PyLibMCCache).
+        image: memcached:alpine
+        ports:
+          - 11211:11211
+    env:
+      LOCAL_ENV: '1'            # local static/media, no AWS, non-secure cookies
+      DB_HOST: localhost
+      DB_PORT: '5432'
+      DB_NAME: postgres
+      DB_USER: postgres
+      DB_PASSWORD: crimson
+      CACHE_LOCATION: localhost:11211
+    defaults:
+      run:
+        working-directory: app/forum
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'   # matches the forum Dockerfile
+          cache: pip
+          cache-dependency-path: app/forum/requirements.txt
+      # pylibmc is built from source and needs the libmemcached headers.
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libmemcached-dev libsasl2-dev
+      - name: Install python dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: python manage.py test user.test_forms utils.test_extra_tags --verbosity 2

--- a/app/forum/user/test_forms.py
+++ b/app/forum/user/test_forms.py
@@ -1,31 +1,32 @@
 from django.test import TestCase
 
-from .models import ForumUser
+from .models import ForumUser, TokenPool
 from .forms import RegisterForm
 
 
 class RegistrationTest(TestCase):
 
-    def setup(self):
-        self.user = ForumUser.objects.create_user(username='jacob',
-            email='jacob@test.com', password='top_secret')
+    def setUp(self):
+        self.existing_user = ForumUser.objects.create_user(
+            username='jacob', email='jacob@test.com', password='top_secret')
+        # RegisterForm.clean_token requires a token that exists in TokenPool
+        # (and consumes it). TokenPool.save() generates the value itself, so
+        # read it back rather than passing one in.
+        self.token = TokenPool.objects.create().token
         self.valid_form_data = {
             'username': 'test',
             'email': 'other@test.com',
             'password1': 'top_secret',
-            'password2': 'top_secret'
+            'password2': 'top_secret',
+            'token': self.token,
         }
 
     def test_email_in_use(self):
-        form_data = {
-            'username': 'test',
-            'email': 'jacob@test.com',
-            'password1': 'top_secret',
-            'password2': 'top_secret'
-        }
+        form_data = {**self.valid_form_data, 'email': 'jacob@test.com'}
         form = RegisterForm(data=form_data)
+        self.assertFalse(form.is_valid())
         self.assertEqual(form.errors['email'], ['Adresse déjà enregistrée.'])
 
     def test_valid_input(self):
         form = RegisterForm(data=self.valid_form_data)
-        self.assertEqual(form.is_valid(), True)
+        self.assertTrue(form.is_valid(), form.errors.as_json())


### PR DESCRIPTION
Follow-up to #142 (which added the websocket CI job). This fixes the Django form tests and wires the Python tests into CI.

## The problem

`user/test_forms.py` had never run (there was no CI) and had rotted:

- `def setup` was a typo for `setUp`, so it never executed → `self.valid_form_data` was undefined (`AttributeError`) and no existing user was created, so `test_email_in_use` did `form.errors['email']` on a form with no email error (`KeyError`).
- The form data omitted `token`, which `RegisterForm.clean_token` now requires.

## The fix

- Use `setUp`; create the existing user **and** a `TokenPool` token (read back from the auto-generated value, since `TokenPool.save()` generates it), and include the token in the form data.
- Assert both the "email already registered" error and a fully-valid registration.

## CI

Adds a `forum` job to `.github/workflows/test.yml`:

- **Postgres** service (the form tests use `django.test.TestCase`).
- **memcached** service — `ForumUser`'s `post_save` signal writes to the cache (settings use `PyLibMCCache`), so a backend must be reachable.
- Python 3.10 (matches the forum Dockerfile), `libmemcached-dev`/`libsasl2-dev` for building `pylibmc`, `pip install -r requirements.txt`.
- Runs `python manage.py test user.test_forms utils.test_extra_tags`.

The vendored `utils/postmarkup` suite is intentionally skipped — it's a third-party package with its own `import postmarkup` convention and runs standalone from its own directory, not via Django's test runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)