### PR TITLE
Add forum model tests, fix postmarkup URL encoding, expand CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,4 +70,23 @@ jobs:
       - name: Install python dependencies
         run: pip install -r requirements.txt
       - name: Run tests
-        run: python manage.py test user.test_forms utils.test_extra_tags --verbosity 2
+        run: python manage.py test user.test_forms utils.test_extra_tags forum.test_models forum.test_util --verbosity 2
+
+  postmarkup:
+    name: postmarkup (vendored bbcode lib)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app/forum/utils/postmarkup
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      # The vendored suite exercises create() with syntax highlighting, which
+      # needs Pygments (the app itself runs with use_pygments=False, so it is
+      # only a test dependency here).
+      - name: Install test dependencies
+        run: pip install pygments
+      - name: Run tests
+        run: python -m unittest postmarkup.tests --verbose

--- a/app/forum/forum/test_models.py
+++ b/app/forum/forum/test_models.py
@@ -1,0 +1,143 @@
+import datetime
+
+from django.test import TestCase
+from django.utils import timezone
+
+from user.models import ForumUser, Bookmark
+from .models import Category, Thread, Post, UserMentions
+
+
+class ForumTestMixin:
+    """Shared fixtures: an author and a category."""
+
+    def setUp(self):
+        self.author = ForumUser.objects.create_user(
+            username='alice', email='alice@test.com', password='top_secret')
+        self.category = Category.objects.create(
+            slug='general', title='General', subtitle='General chat')
+
+    def make_thread(self, title='Hello World', author=None):
+        return Thread.objects.create(
+            title=title, author=author or self.author, category=self.category)
+
+
+class ThreadSaveTests(ForumTestMixin, TestCase):
+
+    def test_new_thread_slug_derives_from_title(self):
+        self.assertEqual(self.make_thread(title='Hello World').slug, 'hello-world')
+
+    def test_new_thread_gets_a_50_char_cession_token(self):
+        thread = self.make_thread()
+        self.assertEqual(len(thread.cessionToken), 50)
+
+    def test_cession_tokens_are_unique_across_threads(self):
+        t1 = self.make_thread(title='One')
+        t2 = self.make_thread(title='Two')
+        self.assertNotEqual(t1.cessionToken, t2.cessionToken)
+
+    def test_duplicate_title_gets_a_distinct_slug_in_same_category(self):
+        first = self.make_thread(title='Same Title')
+        second = self.make_thread(title='Same Title')
+        self.assertNotEqual(first.slug, second.slug)
+
+    def test_untitled_thread_falls_back_to_sans_titre(self):
+        # A title made only of punctuation slugifies to an empty string.
+        thread = self.make_thread(title='!!!')
+        self.assertTrue(thread.slug.startswith('sans-titre'))
+
+    def test_cession_token_regenerates_when_author_changes(self):
+        thread = self.make_thread()
+        original = thread.cessionToken
+        thread.author = ForumUser.objects.create_user(
+            username='bob', email='bob@test.com', password='top_secret')
+        thread.save()
+        self.assertNotEqual(thread.cessionToken, original)
+
+    def test_placeholder_tmp_token_is_regenerated_on_save(self):
+        thread = self.make_thread()
+        thread.cessionToken = 'tmp'
+        thread.save()
+        self.assertNotEqual(thread.cessionToken, 'tmp')
+        self.assertEqual(len(thread.cessionToken), 50)
+
+    def test_creating_a_thread_bookmarks_it_for_the_author(self):
+        thread = self.make_thread()
+        self.assertTrue(
+            Bookmark.objects.filter(user=self.author, thread=thread).exists())
+
+
+class PostSaveTests(ForumTestMixin, TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.thread = self.make_thread()
+
+    def test_post_author_is_added_to_thread_contributors(self):
+        bob = ForumUser.objects.create_user(
+            username='bob', email='bob@test.com', password='top_secret')
+        Post.objects.create(content_plain='hi', author=bob, thread=self.thread)
+        self.assertIn(bob, self.thread.contributors.all())
+
+    def test_new_post_bumps_thread_modified_to_post_created(self):
+        # Push modified into the past without going through Thread.save().
+        past = timezone.now() - datetime.timedelta(days=2)
+        Thread.objects.filter(pk=self.thread.pk).update(modified=past)
+        when = timezone.now()
+        Post.objects.create(
+            content_plain='hi', author=self.author, thread=self.thread, created=when)
+        self.thread.refresh_from_db()
+        self.assertEqual(self.thread.modified, when)
+
+    def test_editing_a_post_does_not_bump_thread_modified(self):
+        post = Post.objects.create(
+            content_plain='hi', author=self.author, thread=self.thread)
+        self.thread.refresh_from_db()
+        modified_after_create = self.thread.modified
+        post.content_plain = 'edited'
+        post.save()
+        self.thread.refresh_from_db()
+        self.assertEqual(self.thread.modified, modified_after_create)
+
+
+class MentionSignalTests(ForumTestMixin, TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.thread = self.make_thread()
+
+    def test_mentioning_a_user_records_it_and_flags_them(self):
+        bob = ForumUser.objects.create_user(
+            username='bob', email='bob@test.com', password='top_secret')
+        self.assertFalse(bob.newMention)
+        post = Post.objects.create(
+            content_plain='hey @bob look at this',
+            author=self.author, thread=self.thread)
+        self.assertTrue(
+            UserMentions.objects.filter(user=bob, post=post).exists())
+        bob.refresh_from_db()
+        self.assertTrue(bob.newMention)
+
+    def test_mentioning_an_unknown_user_is_ignored(self):
+        post = Post.objects.create(
+            content_plain='hey @nobody', author=self.author, thread=self.thread)
+        self.assertFalse(UserMentions.objects.filter(post=post).exists())
+
+
+class PostCountTests(ForumTestMixin, TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.thread = self.make_thread()
+
+    def test_thread_post_count_excludes_the_opening_post(self):
+        for i in range(3):
+            Post.objects.create(
+                content_plain=f'post {i}', author=self.author, thread=self.thread)
+        # post_count is posts.count() - 1 (the opening post is not counted).
+        self.assertEqual(self.thread.post_count, 2)
+
+    def test_category_post_count_totals_posts_across_threads(self):
+        other = self.make_thread(title='Other')
+        Post.objects.create(content_plain='a', author=self.author, thread=self.thread)
+        Post.objects.create(content_plain='b', author=self.author, thread=other)
+        self.assertEqual(self.category.post_count, 2)

--- a/app/forum/forum/test_util.py
+++ b/app/forum/forum/test_util.py
@@ -1,0 +1,30 @@
+from django.test import SimpleTestCase
+
+from .util import normalize_query, keygen
+
+
+class NormalizeQueryTests(SimpleTestCase):
+
+    def test_splits_words_and_groups_quoted_terms(self):
+        # Behaviour documented in normalize_query's own docstring.
+        self.assertEqual(
+            normalize_query(
+                ' some random  words "with   quotes  " and   spaces  '),
+            ['some', 'random', 'words', 'with quotes', 'and', 'spaces'])
+
+    def test_blank_string_yields_no_terms(self):
+        self.assertEqual(normalize_query('    '), [])
+
+
+class KeygenTests(SimpleTestCase):
+
+    ALLOWED = set('abcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*(-_=+)')
+
+    def test_key_has_expected_length_and_charset(self):
+        for _ in range(10):
+            key = keygen()
+            self.assertEqual(len(key), 50)
+            self.assertLessEqual(set(key), self.ALLOWED)
+
+    def test_keys_are_not_repeated(self):
+        self.assertNotEqual(keygen(), keygen())

--- a/app/forum/utils/postmarkup/postmarkup/parser.py
+++ b/app/forum/utils/postmarkup/postmarkup/parser.py
@@ -252,11 +252,18 @@ class LinkTag(TagBase):
         except Exception:
             return ''
 
-        # Only percent-encode path, params, query, fragment
-        safe_path = quote(path, safe="/;")
-        safe_params = quote(params, safe="")
-        safe_query = quote(query, safe="=&?")
-        safe_fragment = quote(fragment, safe="")
+        # Percent-encode unsafe ASCII in the path, query and fragment, but
+        # preserve non-ASCII characters (e.g. accented letters) so URLs stay
+        # human-readable, the way browsers display them. quote() would
+        # otherwise turn "é" into "%C3%A9".
+        def _enc(component, safe):
+            return ''.join(
+                c if ord(c) > 127 else quote(c, safe=safe) for c in component)
+
+        safe_path = _enc(path, "/;")
+        safe_params = _enc(params, "")
+        safe_query = _enc(query, "=&?")
+        safe_fragment = _enc(fragment, "")
         url_fixed = urlunparse((scheme, netloc, safe_path, safe_params, safe_query, safe_fragment))
 
         # Extract domain for annotation


### PR DESCRIPTION
Follow-up to #147. Tackles the two remaining items: (2) test the untested `forum/` app, and (3) hook up the vendored postmarkup suite in CI.

## Forum model/business-logic tests (highest-risk untested area)

`forum/test_models.py` (Django `TestCase`):
- **`Thread.save()`** — slug from title, distinct slug for a duplicate title in the same category, `sans-titre` fallback for a punctuation-only title, 50-char `cessionToken`, token regeneration on author change and on the `tmp` placeholder.
- **`Post.save()`** — author added to `contributors`; a new post bumps `thread.modified` to the post's `created`, while editing an existing post does not.
- **Signals** — a new thread auto-bookmarks itself for its author; `@mention` of a real user records a `UserMentions` row and sets `newMention` (unknown handles are ignored).
- **`post_count`** — thread count excludes the opening post; category count totals across threads.

`forum/test_util.py` (`SimpleTestCase`, no DB) — `normalize_query` and `keygen`.

## Postmarkup: hooked up + bug fixed

Added a standalone **`postmarkup`** CI job. The suite needs Pygments (test-only — the app runs `create(use_pygments=False)`).

Running it surfaced a real bug: the earlier "CoPilot fix parser" commit added `test_url_with_accented_characters` **but never ran it** (no CI). `LinkTag` percent-encoded non-ASCII path characters — `https://fr.wikipedia.org/wiki/Métonymie` → `…/wiki/M%C3%A9tonymie` — mangling the hrefs of accented `[url]`/`[link]` posts. Fix: encode only unsafe ASCII, preserve non-ASCII. All 12 postmarkup tests now pass. (HTML-attribute safety is unchanged: `standard_replace_no_break` still escapes `<`/`>`/`&` and `"` is still percent-encoded.)

## CI

`.github/workflows/test.yml` now has three jobs: **websocket**, **forum** (now also running `forum.test_models` / `forum.test_util`), and **postmarkup**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)