### PR TITLE
Fix XSS: reject non-http(s) schemes in postmarkup [url] tag

### DIFF
--- a/app/forum/utils/postmarkup/postmarkup/parser.py
+++ b/app/forum/utils/postmarkup/postmarkup/parser.py
@@ -240,16 +240,23 @@ class LinkTag(TagBase):
             query = parsed.query
             fragment = parsed.fragment
             if not scheme or not netloc:
-                # fallback for URLs like http://example.com
+                # Fallback for odd inputs: treat everything after the scheme
+                # as the path.
                 scheme, uri = url.split(':', 1)
-                if scheme not in ['http', 'https']:
-                    return ''
                 netloc = ''
                 path = uri
                 params = ''
                 query = ''
                 fragment = ''
         except Exception:
+            return ''
+
+        # Only ever emit http(s) links. Reject javascript:, data:, vbscript:,
+        # etc. in every code path (schemes with a netloc, e.g.
+        # "javascript://%0aalert(1)", would otherwise slip through) to prevent
+        # XSS via the href attribute. urlparse lowercases the scheme, so this
+        # is case-insensitive.
+        if scheme not in ('http', 'https'):
             return ''
 
         # Percent-encode unsafe ASCII in the path, query and fragment, but

--- a/app/forum/utils/postmarkup/postmarkup/tests.py
+++ b/app/forum/utils/postmarkup/postmarkup/tests.py
@@ -123,3 +123,27 @@ class TestPostmarkup(unittest.TestCase):
         input_url = '[link]https://fr.wikipedia.org/wiki/Métonymie[/link]'
         expected = '<a href="https://fr.wikipedia.org/wiki/Métonymie">https://fr.wikipedia.org/wiki/Métonymie</a>'
         self.assertEqual(markup(input_url), expected)
+
+    def test_dangerous_schemes_are_not_linked(self):
+        """[url] must never produce an href for non-http(s) schemes (XSS)."""
+        markup = postmarkup.create(annotate_links=False)
+        dangerous = [
+            "[url]javascript://%0aalert(1)[/url]",  # netloc form bypassed the old check
+            "[url]javascript:alert(1)[/url]",
+            "[url]JAVASCRIPT://alert(1)[/url]",     # scheme match is case-insensitive
+            "[url]vbscript://alert[/url]",
+            "[url]data:text/html,<script>alert(1)</script>[/url]",
+            "[url]ftp://example.com/file[/url]",
+        ]
+        for markup_text in dangerous:
+            rendered = markup(markup_text)
+            self.assertNotIn("<a ", rendered)
+            self.assertNotIn("href", rendered)
+
+    def test_http_and_https_urls_are_linked(self):
+        """Legitimate schemes still render as links."""
+        markup = postmarkup.create(annotate_links=False)
+        for url in ("http://example.com", "https://example.com/path?q=1"):
+            self.assertEqual(
+                markup("[url]%s[/url]" % url),
+                '<a href="%s">%s</a>' % (url, url))


### PR DESCRIPTION
Follow-up to the finding noted in #148: the postmarkup `LinkTag` scheme allow-list only ran in one branch.

## The vulnerability

`LinkTag.render_open` percent-encodes and emits the URL, but only checked the `http`/`https` allow-list inside its **no-netloc fallback** branch. A URL whose scheme carries a `//` netloc parses with both a scheme *and* a netloc, so it **skipped the check** and was emitted verbatim:

```
[url]javascript://%0aalert(1)[/url]  ->  <a href="javascript://%0aalert(1)">…</a>
```

That executes in browsers: `//` comments out the rest of the first line, the `%0a` newline ends the comment, and `alert(...)` runs. `JAVASCRIPT://` (case), `vbscript://`, and `ftp://` slipped through the same way. This is reachable from any user post via the `[url]`/`[link]` bbcode tag.

(The no-`//` forms like `javascript:alert(1)` and `data:text/html,…` were already safe — they parse with no netloc, hit the fallback, and render as plain text.)

## The fix

Move the allow-list to a single **unconditional** check after URL parsing, so every code path is covered. urlparse lowercases the scheme, so the check is case-insensitive. Non-`http(s)` input now renders as inert text instead of a link.

## Tests

Added to the (now CI-run) postmarkup suite:
- `test_dangerous_schemes_are_not_linked` — `javascript://…`, `javascript:…`, `JAVASCRIPT://…`, `vbscript://…`, `data:…`, `ftp://…` all produce no `<a>`/`href`.
- `test_http_and_https_urls_are_linked` — legitimate links still render.

14/14 postmarkup tests pass; the accented-URL behaviour from #148 is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)